### PR TITLE
Delete robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-# https://www.robotstxt.org/robotstxt.html
-User-agent: *
-Disallow: *


### PR DESCRIPTION
Remove robots.txt and allow spiders to index piedao.org

##### Description

piedao.org's robots.txt is preventing Google and other spiders from indexing the site.  

From the commit history, it didn't look like this is intentional? ....but I can't be sure.

<img width="415" alt="Screen Shot 2021-04-18 at 8 43 33 PM" src="https://user-images.githubusercontent.com/6281/115167885-10558000-a087-11eb-9092-9d756943fd6d.png">


##### Checklist

- [x] Changes don't break existing behavior

